### PR TITLE
Remove mutex locking from GenomeAI and ignore VS index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 build/
 summary.gz
-/.vs/repos/FileContentIndex/4d9d76fb-3334-40fa-b17c-2568c989c29d.vsidx
-/.vs/repos/FileContentIndex/363a0313-a71d-466a-b9a9-5e89754348f5.vsidx
+# Ignore Visual Studio cache files
+/.vs/

--- a/streamlit_template/src/core/genome_ai.cpp
+++ b/streamlit_template/src/core/genome_ai.cpp
@@ -85,10 +85,7 @@ AnalysisResult GenomeAI::analyze_sequence(const std::string& sequence, SequenceT
     auto start_time = std::chrono::high_resolution_clock::now();
     
     // Update performance stats
-    {
-        std::lock_guard<std::mutex> lock(stats_mutex_);
-        performance_stats_.sequences_processed++;
-    }
+    performance_stats_.sequences_processed++;
     
     // Delegate to sequence analyzer
     auto result = sequence_analyzer_->analyze(sequence, type);
@@ -312,12 +309,10 @@ bool GenomeAI::download_reference_genome(const std::string& species,
 }
 
 PerformanceStats GenomeAI::get_performance_stats() const {
-    std::lock_guard<std::mutex> lock(stats_mutex_);
     return performance_stats_;
 }
 
 void GenomeAI::reset_performance_stats() {
-    std::lock_guard<std::mutex> lock(stats_mutex_);
     performance_stats_ = {};
 }
 
@@ -345,11 +340,8 @@ void GenomeAI::clear_cache() {
     }
     
     // Clear other caches
-    {
-        std::lock_guard<std::mutex> lock(stats_mutex_);
-        performance_stats_.cache_hits = 0;
-        performance_stats_.cache_misses = 0;
-    }
+    performance_stats_.cache_hits = 0;
+    performance_stats_.cache_misses = 0;
 }
 
 bool GenomeAI::setup_directories() {


### PR DESCRIPTION
## Summary
- avoid potential locks by removing mutex lock_guard usage in GenomeAI
- ignore Visual Studio FileContentIndex cache directory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c808c227c48330b007fb8ee7e120b6